### PR TITLE
Add connection check endpoint wrappers to company info

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ AchClient::AchWorks.s_s_s = 'TST'
 AchClient::AchWorks.wsdl = 'http://tstsvr.achworks.com/dnet/achws.asmx?wsdl'
 ```
 
+AchWorks recommends that you call their "ConnectionCheck" and
+"CheckCompanyStatus" before each request. We've included some wrappers for
+those endpoints in case you want to go that route.
+
+```ruby
+# ConnectionCheck
+AchClient::AchWorks::InputCompanyInfo.build.connection_valid?
+
+#CheckCompanyStatus
+AchClient::AchWorks::InputCompanyInfo.build.company_valid?
+
+# Both
+AchClient::AchWorks::InputCompanyInfo.build.valid?
+```
+
 #### Logging
 
 For record keeping purposes, there is a log provider that allows you to hook

--- a/lib/ach_client/ach_works/input_company_info.rb
+++ b/lib/ach_client/ach_works/input_company_info.rb
@@ -39,6 +39,27 @@ module AchClient
         )
       end
 
+      # Wraps: http://tstsvr.achworks.com/dnet/achws.asmx?op=ConnectionCheck
+      # Checks validity of company info
+      # @return whether or not the request was successful
+      def connection_valid?
+        connection_check_request(method: :connection_check)
+      end
+
+      # Wraps: http://tstsvr.achworks.com/dnet/achws.asmx?op=CheckCompanyStatus
+      # Checks company status
+      # @return whether or not the request was successful
+      def company_valid?
+        connection_check_request(method: :check_company_status)
+      end
+
+      # Calls both company_valid? and connection_valid?
+      # Checks the validity of company info
+      # @return whether or not the validity check requests were successful
+      def valid?
+        connection_valid? && company_valid?
+      end
+
       ##
       # Build a hash to send to ACHWorks under the InpCompanyInfo XML path
       # @return [Hash] hash to send to ACHWorks
@@ -51,6 +72,16 @@ module AchClient
             }
           end.reduce(&:merge)
         }
+      end
+
+      private
+      def connection_check_request(method:)
+        AchClient::AchWorks.request(
+          method: method,
+          message: self.to_hash
+        ).body["#{method}_response".to_sym]["#{method}_result".to_sym].include?(
+          'SUCCESS'
+        )
       end
     end
   end

--- a/test/lib/ach_client/ach_works/input_company_info_test.rb
+++ b/test/lib/ach_client/ach_works/input_company_info_test.rb
@@ -14,4 +14,24 @@ class InputCompanyInfoTest < Minitest::Test
       }
     )
   end
+
+  def test_connection_valid
+    VCR.use_cassette('connection_valid') do
+      assert(AchClient::AchWorks::InputCompanyInfo.build.connection_valid?)
+    end
+  end
+
+  def test_company_valid
+    VCR.use_cassette('company_valid') do
+      assert(AchClient::AchWorks::InputCompanyInfo.build.company_valid?)
+    end
+  end
+
+  def test_that_connection_check_works
+    VCR.use_cassette('company_valid') do
+      VCR.use_cassette('connection_valid') do
+        assert(AchClient::AchWorks::InputCompanyInfo.build.valid?)
+      end
+    end
+  end
 end

--- a/test/vcrs/company_valid.yml
+++ b/test/vcrs/company_valid.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://tstsvr.achworks.com/dnet/achws.asmx
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://achworks.com/"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:CheckCompanyStatus><tns:InpCompanyInfo><tns:Company>MYCOMPANY</tns:Company><tns:CompanyKey>SASD%!%$DGLJGWYRRDGDDUDFDESDHDD</tns:CompanyKey><tns:LocID>9505</tns:LocID><tns:SSS>TST</tns:SSS></tns:InpCompanyInfo></tns:CheckCompanyStatus></env:Body></env:Envelope>
+    headers:
+      Soapaction:
+      - '"http://achworks.com/CheckCompanyStatus"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '513'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Aug 2016 13:20:31 GMT
+      Server:
+      - Apache
+      X-Aspnet-Version:
+      - 2.0.50727
+      Cache-Control:
+      - private, max-age=0
+      Content-Length:
+      - '417'
+      Content-Type:
+      - text/xml; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><CheckCompanyStatusResponse
+        xmlns="http://achworks.com/"><CheckCompanyStatusResult>SUCCESS:Valid And Active
+        Account</CheckCompanyStatusResult></CheckCompanyStatusResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Thu, 11 Aug 2016 14:13:05 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcrs/connection_valid.yml
+++ b/test/vcrs/connection_valid.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://tstsvr.achworks.com/dnet/achws.asmx
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://achworks.com/"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:ConnectionCheck><tns:InpCompanyInfo><tns:Company>MYCOMPANY</tns:Company><tns:CompanyKey>SASD%!%$DGLJGWYRRDGDDUDFDESDHDD</tns:CompanyKey><tns:LocID>9505</tns:LocID><tns:SSS>TST</tns:SSS></tns:InpCompanyInfo></tns:ConnectionCheck></env:Body></env:Envelope>
+    headers:
+      Soapaction:
+      - '"http://achworks.com/ConnectionCheck"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '507'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 22 Aug 2016 13:20:31 GMT
+      Server:
+      - Apache
+      X-Aspnet-Version:
+      - 2.0.50727
+      Cache-Control:
+      - private, max-age=0
+      Content-Length:
+      - '394'
+      Content-Type:
+      - text/xml; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><ConnectionCheckResponse
+        xmlns="http://achworks.com/"><ConnectionCheckResult>SUCCESS:Valid Account</ConnectionCheckResult></ConnectionCheckResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Thu, 11 Aug 2016 14:13:05 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
AchWorks recommend we hit both of these endpoints before every request to make sure our company details check out, and that their service is up. 
Added some functionality to call those endpoints in case we want to go that route.
