### PR TITLE
Returns should have the same front-end-trace they were given in the transaction

### DIFF
--- a/lib/ach_client/ach_works/ach_status_checker.rb
+++ b/lib/ach_client/ach_works/ach_status_checker.rb
@@ -65,7 +65,7 @@ module AchClient
             record[:front_end_trace].present?
           end.map do |record|
             {
-              record[:front_end_trace] =>
+              record[:front_end_trace][1..-1] =>
               AchClient::AchWorks::ResponseRecordProcessor
                 .process_response_record(record)
             }

--- a/test/lib/ach_client/ach_works/ach_status_checker_test.rb
+++ b/test/lib/ach_client/ach_works/ach_status_checker_test.rb
@@ -23,87 +23,87 @@ class AchStatusChecker < MiniTest::Test
     VCR.use_cassette('most_recent') do
       response = status_checker.most_recent
 
-      assert(response['WRG-SCRUB0'].is_a?(AchClient::ReturnedAchResponse))
-      assert(response['WRG-SCRUB0'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB0'].is_a?(AchClient::ReturnedAchResponse))
+      assert(response['RG-SCRUB0'].date.is_a?(DateTime))
       assert_equal(
-        response['WRG-SCRUB0'].return_code,
+        response['RG-SCRUB0'].return_code,
         AchClient::ReturnCodes.find_by(code: 'R01')
       )
 
-      assert(response['WRG-SCRUB1'].is_a?(AchClient::ProcessingAchResponse))
-      assert(response['WRG-SCRUB1'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB1'].is_a?(AchClient::ProcessingAchResponse))
+      assert(response['RG-SCRUB1'].date.is_a?(DateTime))
 
-      assert(response['WRG-SCRUB2'].is_a?(AchClient::SettledAchResponse))
-      assert(response['WRG-SCRUB2'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB2'].is_a?(AchClient::SettledAchResponse))
+      assert(response['RG-SCRUB2'].date.is_a?(DateTime))
 
-      assert(response['WRG-SCRUB3'].is_a?(AchClient::ReturnedAchResponse))
-      assert(response['WRG-SCRUB3'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB3'].is_a?(AchClient::ReturnedAchResponse))
+      assert(response['RG-SCRUB3'].date.is_a?(DateTime))
       assert_equal(
-        response['WRG-SCRUB3'].return_code,
+        response['RG-SCRUB3'].return_code,
         AchClient::ReturnCodes.find_by(code: 'R01')
       )
 
-      assert(response['WRG-SCRUB4'].is_a?(AchClient::CorrectedAchResponse))
-      assert(response['WRG-SCRUB4'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB4'].is_a?(AchClient::CorrectedAchResponse))
+      assert(response['RG-SCRUB4'].date.is_a?(DateTime))
       assert_equal(
-        response['WRG-SCRUB4'].return_code,
+        response['RG-SCRUB4'].return_code,
         AchClient::ReturnCodes.find_by(code: 'C01')
       )
       assert_equal(
-        response['WRG-SCRUB4'].corrections[:unhandled_correction_data],
+        response['RG-SCRUB4'].corrections[:unhandled_correction_data],
         "2323044                      "
       )
       assert_includes(
-        response['WRG-SCRUB4'].corrections[:note],
+        response['RG-SCRUB4'].corrections[:note],
         "can't tell you what this data means"
       )
 
-      assert(response['WRG-SCRUB5'].is_a?(AchClient::CorrectedAchResponse))
-      assert(response['WRG-SCRUB5'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB5'].is_a?(AchClient::CorrectedAchResponse))
+      assert(response['RG-SCRUB5'].date.is_a?(DateTime))
       assert_equal(
-        response['WRG-SCRUB5'].return_code,
+        response['RG-SCRUB5'].return_code,
         AchClient::ReturnCodes.find_by(code: 'C03')
       )
       assert_equal(
-        response['WRG-SCRUB5'].corrections[:routing_number],
+        response['RG-SCRUB5'].corrections[:routing_number],
         "123456780"
       )
       assert_equal(
-        response['WRG-SCRUB5'].corrections[:account_number],
+        response['RG-SCRUB5'].corrections[:account_number],
         "30441234567802323"
       )
 
-      assert(response['WRG-SCRUB6'].is_a?(AchClient::CorrectedAchResponse))
-      assert(response['WRG-SCRUB6'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB6'].is_a?(AchClient::CorrectedAchResponse))
+      assert(response['RG-SCRUB6'].date.is_a?(DateTime))
       assert_equal(
-        response['WRG-SCRUB6'].return_code,
+        response['RG-SCRUB6'].return_code,
         AchClient::ReturnCodes.find_by(code: 'C06')
       )
       assert_equal(
-        response['WRG-SCRUB6'].corrections[:account_number],
+        response['RG-SCRUB6'].corrections[:account_number],
         "000023230CC000023"
       )
       assert_equal(
-        response['WRG-SCRUB6'].corrections[:account_type],
+        response['RG-SCRUB6'].corrections[:account_type],
         AccountTypes::Checking
       )
 
-      assert(response['WRG-SCRUB7'].is_a?(AchClient::CorrectedAchResponse))
-      assert(response['WRG-SCRUB7'].date.is_a?(DateTime))
+      assert(response['RG-SCRUB7'].is_a?(AchClient::CorrectedAchResponse))
+      assert(response['RG-SCRUB7'].date.is_a?(DateTime))
       assert_equal(
-        response['WRG-SCRUB7'].return_code,
+        response['RG-SCRUB7'].return_code,
         AchClient::ReturnCodes.find_by(code: 'C07')
       )
       assert_equal(
-        response['WRG-SCRUB7'].corrections[:routing_number],
+        response['RG-SCRUB7'].corrections[:routing_number],
         "000023230"
       )
       assert_equal(
-        response['WRG-SCRUB7'].corrections[:account_type],
+        response['RG-SCRUB7'].corrections[:account_type],
         AccountTypes::Checking
       )
       assert_equal(
-        response['WRG-SCRUB7'].corrections[:account_number],
+        response['RG-SCRUB7'].corrections[:account_number],
         "CC000023230CC888C"
       )
 


### PR DESCRIPTION
We add an extra character to the user supplied front-end trace when
we send it to AchWorks to ensure that it does not start with the
Forbidden 'W'. When processing returns, we should remove that extra
first character so that the consumer can match the front end trace
against the value they provided in the first place.
(In the test examples, the FrontEndTraces start with W's because the example data I used originated from web console transactions)
