### PR TITLE
account and transaction types should be in AchClient namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ batch = AchClient::AchBatch.new(
   ach_transactions: [
     AchClient::AchTransaction.new(
       account_number: '00002323044',
-      account_type: AccountTypes::Checking,
+      account_type: AchClient::AccountTypes::Checking,
       amount: BigDecimal.new('575.45'),
       memo: '????',
       merchant_name: 'DOE, JOHN',
       routing_number: nil,
-      transaction_type: TransactionTypes::Credit,
+      transaction_type: AchClient::TransactionTypes::Credit,
       ach_id: 'foooo'
     ),
     ...

--- a/lib/ach_client/abstract/ach_transaction.rb
+++ b/lib/ach_client/abstract/ach_transaction.rb
@@ -23,14 +23,14 @@ module AchClient
 
       ##
       # @param account_number [String] Merchant's account number
-      # @param account_type [AccountTypes::AccountType] Merchant's account type
-      #   (debit or credit), must be an instance of AccountTypes::AccountType
+      # @param account_type [AchClient::AccountTypes::AccountType] Merchant's account type
+      #   (debit or credit), must be an instance of AchClient::AccountTypes::AccountType
       # @param amount [BigDecimal] Amount of the ACH transaction
       # @param memo [String] Ach memo thing
       # @param merchant_name [String] Name associated with merchantaccount we
       #   are ACHing with
       # @param routing_number [String] Routing number of the merchant's account
-      # @param transaction_type [TransactionTypes::TransactionType] debit or
+      # @param transaction_type [AchClient::TransactionTypes::TransactionType] debit or
       def initialize(*arguments)
         args = arguments.extract_options!
         self.class.arguments.each do |param|
@@ -43,12 +43,12 @@ module AchClient
 
       # @return [Boolean] true if transaction is a debit
       def debit?
-        transaction_type == TransactionTypes::Debit
+        transaction_type == AchClient::TransactionTypes::Debit
       end
 
       # @return [Boolean] true if transaction is a credit
       def credit?
-        transaction_type == TransactionTypes::Credit
+        transaction_type == AchClient::TransactionTypes::Credit
       end
     end
   end

--- a/lib/ach_client/account_types.rb
+++ b/lib/ach_client/account_types.rb
@@ -1,14 +1,16 @@
-## Representations of merchant account types (checking or savings)
-module AccountTypes
-  ## Base class for all account types
-  class AccountType
-  end
+module AchClient
+  ## Representations of merchant account types (checking or savings)
+  module AccountTypes
+    ## Base class for all account types
+    class AccountType
+    end
 
-  ## Represents a checking account
-  class Checking < AccountTypes::AccountType
-  end
+    ## Represents a checking account
+    class Checking < AchClient::AccountTypes::AccountType
+    end
 
-  ## Represents a savings account
-  class Savings < AccountTypes::AccountType
+    ## Represents a savings account
+    class Savings < AchClient::AccountTypes::AccountType
+    end
   end
 end

--- a/lib/ach_client/ach_works/account_type_transformer.rb
+++ b/lib/ach_client/ach_works/account_type_transformer.rb
@@ -10,8 +10,8 @@ module AchClient
       # @return [Hash {String => Class}] the mapping
       def self.string_to_class_map
         {
-          'S' => AccountTypes::Savings,
-          'C' => AccountTypes::Checking
+          'S' => AchClient::AccountTypes::Savings,
+          'C' => AchClient::AccountTypes::Checking
         }
       end
     end

--- a/lib/ach_client/ach_works/ach_works_transformer.rb
+++ b/lib/ach_client/ach_works/ach_works_transformer.rb
@@ -9,8 +9,8 @@ module AchClient
       # Convert AchWorks string representation to AchClient class
       # =>  representation
       # @param string [String] string to turn into class
-      # @return [Class] for example AccountTypes::Checking or
-      # AccountTypes::Savings
+      # @return [Class] for example AchClient::AccountTypes::Checking or
+      # AchClient::AccountTypes::Savings
       def self.string_to_class(string)
         self.string_to_class_map[string] or raise(
           "Unknown #{self} string #{string}"

--- a/lib/ach_client/ach_works/transaction_type_transformer.rb
+++ b/lib/ach_client/ach_works/transaction_type_transformer.rb
@@ -11,8 +11,8 @@ module AchClient
       # @return [Hash {String => Class}] the mapping
       def self.string_to_class_map
         {
-          'C' => TransactionTypes::Credit,
-          'D' => TransactionTypes::Debit
+          'C' => AchClient::TransactionTypes::Credit,
+          'D' => AchClient::TransactionTypes::Debit
         }
       end
     end

--- a/lib/ach_client/transaction_types.rb
+++ b/lib/ach_client/transaction_types.rb
@@ -1,14 +1,16 @@
-## Representations of Ach transaction types (debit or credit)
-module TransactionTypes
-  ## Base class for all transaction types
-  class TransactionType
-  end
+module AchClient
+  ## Representations of Ach transaction types (debit or credit)
+  module TransactionTypes
+    ## Base class for all transaction types
+    class TransactionType
+    end
 
-  ## Representation of a credit transaction type
-  class Credit < TransactionTypes::TransactionType
-  end
+    ## Representation of a credit transaction type
+    class Credit < AchClient::TransactionTypes::TransactionType
+    end
 
-  ## Representation of a debit transaction type
-  class Debit < TransactionTypes::TransactionType
+    ## Representation of a debit transaction type
+    class Debit < AchClient::TransactionTypes::TransactionType
+    end
   end
 end

--- a/test/lib/ach_client/ach_works/account_type_transformer_test.rb
+++ b/test/lib/ach_client/ach_works/account_type_transformer_test.rb
@@ -4,12 +4,12 @@ class AccountTypeTransformerTest < MiniTest::Test
   def test_string_to_class
     assert_equal(
       AchClient::AchWorks::AccountTypeTransformer.string_to_class('C'),
-      AccountTypes::Checking
+      AchClient::AccountTypes::Checking
     )
 
     assert_equal(
       AchClient::AchWorks::AccountTypeTransformer.string_to_class('S'),
-      AccountTypes::Savings
+      AchClient::AccountTypes::Savings
     )
 
     assert_equal(
@@ -23,13 +23,13 @@ class AccountTypeTransformerTest < MiniTest::Test
   def test_class_to_string
     assert_equal(
       AchClient::AchWorks::AccountTypeTransformer.class_to_string(
-        AccountTypes::Checking
+        AchClient::AccountTypes::Checking
       ),
       'C'
     )
     assert_equal(
       AchClient::AchWorks::AccountTypeTransformer.class_to_string(
-        AccountTypes::Savings
+        AchClient::AccountTypes::Savings
       ),
       'S'
     )
@@ -37,7 +37,7 @@ class AccountTypeTransformerTest < MiniTest::Test
       assert_raises(RuntimeError) do
         AchClient::AchWorks::AccountTypeTransformer.class_to_string(Class)
       end.message,
-      'type must be one of AccountTypes::Savings, AccountTypes::Checking'
+      'type must be one of AchClient::AccountTypes::Savings, AchClient::AccountTypes::Checking'
     )
   end
 end

--- a/test/lib/ach_client/ach_works/ach_batch_test.rb
+++ b/test/lib/ach_client/ach_works/ach_batch_test.rb
@@ -4,12 +4,12 @@ class AchBatchTest < MiniTest::Test
   def debit
     AchClient::AchWorks::AchTransaction.new(
       account_number: '00002323044',
-      account_type: AccountTypes::Checking,
+      account_type: AchClient::AccountTypes::Checking,
       amount: BigDecimal.new('575.45'),
       memo: '????',
       merchant_name: 'DOE, JOHN',
       routing_number: '123456780',
-      transaction_type: TransactionTypes::Debit,
+      transaction_type: AchClient::TransactionTypes::Debit,
       ach_id: 'foooo'
     )
   end
@@ -17,12 +17,12 @@ class AchBatchTest < MiniTest::Test
   def credit
     AchClient::AchWorks::AchTransaction.new(
       account_number: '00002323044',
-      account_type: AccountTypes::Checking,
+      account_type: AchClient::AccountTypes::Checking,
       amount: BigDecimal.new('575.45'),
       memo: '????',
       merchant_name: 'DOE, JOHN',
       routing_number: '123456780',
-      transaction_type: TransactionTypes::Credit,
+      transaction_type: AchClient::TransactionTypes::Credit,
       ach_id: 'foooo'
     )
   end
@@ -30,12 +30,12 @@ class AchBatchTest < MiniTest::Test
   def invalid
     AchClient::AchWorks::AchTransaction.new(
       account_number: '00002323044',
-      account_type: AccountTypes::Checking,
+      account_type: AchClient::AccountTypes::Checking,
       amount: BigDecimal.new('575.45'),
       memo: '????',
       merchant_name: 'DOE, JOHN',
       routing_number: nil,
-      transaction_type: TransactionTypes::Credit,
+      transaction_type: AchClient::TransactionTypes::Credit,
       ach_id: 'foooo'
     )
   end

--- a/test/lib/ach_client/ach_works/ach_status_checker_test.rb
+++ b/test/lib/ach_client/ach_works/ach_status_checker_test.rb
@@ -85,7 +85,7 @@ class AchStatusChecker < MiniTest::Test
       )
       assert_equal(
         response['RG-SCRUB6'].corrections[:account_type],
-        AccountTypes::Checking
+        AchClient::AccountTypes::Checking
       )
 
       assert(response['RG-SCRUB7'].is_a?(AchClient::CorrectedAchResponse))
@@ -100,7 +100,7 @@ class AchStatusChecker < MiniTest::Test
       )
       assert_equal(
         response['RG-SCRUB7'].corrections[:account_type],
-        AccountTypes::Checking
+        AchClient::AccountTypes::Checking
       )
       assert_equal(
         response['RG-SCRUB7'].corrections[:account_number],

--- a/test/lib/ach_client/ach_works/ach_transaction_test.rb
+++ b/test/lib/ach_client/ach_works/ach_transaction_test.rb
@@ -5,12 +5,12 @@ class AchTransactionTest < MiniTest::Test
     assert_equal(
       AchClient::AchWorks::AchTransaction.new(
         account_number: '00002323044',
-        account_type: AccountTypes::Checking,
+        account_type: AchClient::AccountTypes::Checking,
         amount: BigDecimal.new('575.45'),
         memo: '????',
         merchant_name: 'DOE, JOHN',
         routing_number: '123456780',
-        transaction_type: TransactionTypes::Debit,
+        transaction_type: AchClient::TransactionTypes::Debit,
         ach_id: 'foooo'
       ).to_hash,
       {
@@ -37,12 +37,12 @@ class AchTransactionTest < MiniTest::Test
     assert_equal(
       AchClient::AchWorks::AchTransaction.new(
         account_number: '00002323044',
-        account_type: AccountTypes::Savings,
+        account_type: AchClient::AccountTypes::Savings,
         amount: BigDecimal.new('575.45'),
         memo: '????',
         merchant_name: 'DOE, JOHN',
         routing_number: '123456780',
-        transaction_type: TransactionTypes::Credit,
+        transaction_type: AchClient::TransactionTypes::Credit,
         ach_id: 'foooo'
       ).to_hash,
       {
@@ -71,12 +71,12 @@ class AchTransactionTest < MiniTest::Test
     assert_raises(RuntimeError) do
       AchClient::AchWorks::AchTransaction.new(
         account_number: '00002323044',
-        account_type: AccountTypes::Savings,
+        account_type: AchClient::AccountTypes::Savings,
         amount: 575.45,
         memo: '????',
         merchant_name: 'DOE, JOHN',
         routing_number: '123456780',
-        transaction_type: TransactionTypes::Credit,
+        transaction_type: AchClient::TransactionTypes::Credit,
         ach_id: '123456789012' # too long
       ).to_hash
     end
@@ -89,7 +89,7 @@ class AchTransactionTest < MiniTest::Test
         memo: '????',
         merchant_name: 'DOE, JOHN',
         routing_number: '123456780',
-        transaction_type: TransactionTypes::Credit,
+        transaction_type: AchClient::TransactionTypes::Credit,
         ach_id: 'foo'
       ).to_hash
     end
@@ -97,7 +97,7 @@ class AchTransactionTest < MiniTest::Test
     assert_raises(RuntimeError) do
       AchClient::AchWorks::AchTransaction.new(
         account_number: '00002323044',
-        account_type: AccountTypes::Savings,
+        account_type: AchClient::AccountTypes::Savings,
         amount: 575.45,
         memo: '????',
         merchant_name: 'DOE, JOHN',

--- a/test/lib/ach_client/ach_works/transaction_type_transformer_test.rb
+++ b/test/lib/ach_client/ach_works/transaction_type_transformer_test.rb
@@ -4,12 +4,12 @@ class TransactionTypeTransformerTest < MiniTest::Test
   def test_string_to_class
     assert_equal(
       AchClient::AchWorks::TransactionTypeTransformer.string_to_class('C'),
-      TransactionTypes::Credit
+      AchClient::TransactionTypes::Credit
     )
 
     assert_equal(
       AchClient::AchWorks::TransactionTypeTransformer.string_to_class('D'),
-      TransactionTypes::Debit
+      AchClient::TransactionTypes::Debit
     )
 
     assert_equal(
@@ -23,13 +23,13 @@ class TransactionTypeTransformerTest < MiniTest::Test
   def test_class_to_string
     assert_equal(
       AchClient::AchWorks::TransactionTypeTransformer.class_to_string(
-        TransactionTypes::Credit
+        AchClient::TransactionTypes::Credit
       ),
       'C'
     )
     assert_equal(
       AchClient::AchWorks::TransactionTypeTransformer.class_to_string(
-        TransactionTypes::Debit
+        AchClient::TransactionTypes::Debit
       ),
       'D'
     )
@@ -37,7 +37,7 @@ class TransactionTypeTransformerTest < MiniTest::Test
       assert_raises(RuntimeError) do
         AchClient::AchWorks::TransactionTypeTransformer.class_to_string(Class)
       end.message,
-      'type must be one of TransactionTypes::Credit, TransactionTypes::Debit'
+      'type must be one of AchClient::TransactionTypes::Credit, AchClient::TransactionTypes::Debit'
     )
   end
 end


### PR DESCRIPTION
Diff looks super weird, but I just added module around the contents of each file

```
module AchClient
  ... old file contents ...
end
```
