### PR TITLE
ACH transactions should be individually sendable to achworks

### DIFF
--- a/lib/ach_client/ach_works/ach_transaction.rb
+++ b/lib/ach_client/ach_works/ach_transaction.rb
@@ -15,6 +15,18 @@ module AchClient
       attr_reader :ach_id,
                   :customer_id
 
+      # Send this transaction individually to AchWorks
+      # @return [String] the front end trace
+      def send
+        AchClient::AchWorks.wrap_request(
+          method: :send_ach_trans,
+          message: AchClient::AchWorks::InputCompanyInfo.build.to_hash.merge({
+            InpACHTransRecord: self.to_hash
+          }),
+          path: [:send_ach_trans_response, :send_ach_trans_result]
+        )[:front_end_trace]
+      end
+
       ##
       # @return [Hash] turns this transaction into a hash that can be sent to
       # AchWorks

--- a/test/lib/ach_client/ach_works/ach_transaction_test.rb
+++ b/test/lib/ach_client/ach_works/ach_transaction_test.rb
@@ -113,4 +113,25 @@ class AchTransactionTest < MiniTest::Test
       ).to_hash
     end
   end
+
+  def test_send
+    VCR.use_cassette('ach_works_ach_transaction_success') do
+      assert_equal(
+        AchClient::AchWorks::AchTransaction.new(
+          account_number: '00002323044',
+          account_type: AchClient::AccountTypes::Checking,
+          amount: BigDecimal.new('575.45'),
+          memo: '????',
+          merchant_name: 'DOE, JOHN',
+          originator_name: 'ff',
+          routing_number: '123456780',
+          sec_code: 'CCD',
+          transaction_type: AchClient::TransactionTypes::Debit,
+          ach_id: 'foooo',
+          customer_id: 'foo'
+        ).send,
+        'Zfoooo'
+      )
+    end
+  end
 end

--- a/test/vcrs/ach_works_ach_transaction_success.yml
+++ b/test/vcrs/ach_works_ach_transaction_success.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://tstsvr.achworks.com/dnet/achws.asmx
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="http://achworks.com/"
+        xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><tns:SendACHTrans><tns:InpCompanyInfo><tns:Company>MYCOMPANY</tns:Company><tns:CompanyKey>SASD%!%$DGLJGWYRRDGDDUDFDESDHDD</tns:CompanyKey><tns:LocID>9505</tns:LocID><tns:SSS>TST</tns:SSS></tns:InpCompanyInfo><tns:InpACHTransRecord><tns:SSS>TST</tns:SSS><tns:LocID>9505</tns:LocID><tns:FrontEndTrace>Zfoooo</tns:FrontEndTrace><tns:CustomerName>DOE,
+        JOHN</tns:CustomerName><tns:CustomerRoutingNo>123456780</tns:CustomerRoutingNo><tns:CustomerAcctNo>00002323044</tns:CustomerAcctNo><tns:OriginatorName>ff</tns:OriginatorName><tns:TransactionCode>CCD</tns:TransactionCode><tns:CustTransType>D</tns:CustTransType><tns:CustomerID>foo</tns:CustomerID><tns:CustomerAcctType>C</tns:CustomerAcctType><tns:TransAmount>575.45</tns:TransAmount><tns:CheckOrTransDate>2016-08-11T00:00:00.00000+00:00</tns:CheckOrTransDate><tns:EffectiveDate>2016-08-11T00:00:00.00000+00:00</tns:EffectiveDate><tns:Memo>????</tns:Memo><tns:OpCode>S</tns:OpCode><tns:AccountSet>1</tns:AccountSet></tns:InpACHTransRecord></tns:SendACHTrans></env:Body></env:Envelope>
+    headers:
+      Soapaction:
+      - '"http://achworks.com/SendACHTrans"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '1279'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 07 Sep 2016 20:37:28 GMT
+      Server:
+      - Apache
+      X-Aspnet-Version:
+      - 2.0.50727
+      Cache-Control:
+      - private, max-age=0
+      Content-Length:
+      - '736'
+      Content-Type:
+      - text/xml; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><SendACHTransResponse
+        xmlns="http://achworks.com/"><SendACHTransResult><SSS>TST</SSS><LocID>9505</LocID><Status>SUCCESS</Status><Details>Transaction
+        record received and queued on 09/07/2016 01:37:28 PM Pacific Time [FrontEndTrace=Zfoooo].
+        Server Processing Time:15.625 ms</Details><CallMethod>SendACHTrans</CallMethod><CallDateTime>2016-09-07T13:37:28.25-07:00</CallDateTime><FrontEndTrace>Zfoooo</FrontEndTrace><TotalNumErrors>0</TotalNumErrors></SendACHTransResult></SendACHTransResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Thu, 11 Aug 2016 14:13:05 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Turns out ICheckGateway doesn't support batch transactions. So I added individual transactions to AchWorks since we will probably end up using that across the board for consistency
