### PR TITLE
Handle negative amounts in NACHA transactions

### DIFF
--- a/lib/ach_client/providers/sftp/ach_transaction.rb
+++ b/lib/ach_client/providers/sftp/ach_transaction.rb
@@ -16,7 +16,7 @@ module AchClient
         entry.transaction_code = transaction_code
         entry.routing_number = routing_number
         entry.account_number = account_number
-        entry.amount = Helpers::DollarsToCents.dollars_to_cents(amount)
+        entry.amount = amount_in_cents
         entry.individual_id_number = external_ach_id # Doesn't need to be a number
         entry.individual_name = merchant_name
         entry.originating_dfi_identification =
@@ -26,15 +26,36 @@ module AchClient
       end
 
       private
+
+      def amount_in_cents
+        # Take absolute value in case amount is negative
+        Helpers::DollarsToCents.dollars_to_cents(amount.abs)
+      end
+
       def transaction_code
         [
           AccountTypeTransformer.serialize_to_provider_value(
             account_type
           ),
           TransactionTypeTransformer.serialize_to_provider_value(
-            transaction_type
+            potentially_flipped_transaction_type
           )
         ].reduce(&:+)
+      end
+
+      # Some NACHA providers can't handle negative amounts
+      # So we flip the amount and toggle the transaction type between
+      #   Debit and Credit or vice versa
+      def potentially_flipped_transaction_type
+        if amount.negative?
+          if transaction_type == TransactionTypes::Credit
+            TransactionTypes::Debit
+          else
+            TransactionTypes::Credit
+          end
+        else
+          self.transaction_type
+        end
       end
     end
   end

--- a/test/lib/ach_client/silicon_valley_bank/ach_transaction_test.rb
+++ b/test/lib/ach_client/silicon_valley_bank/ach_transaction_test.rb
@@ -38,5 +38,41 @@ class SiliconValleyBank
         'NACHA/SFTP providers do not support individual transactions'
       )
     end
+
+    def test_swaps_negative_debit_to_positive_credit
+      entry = AchClient::SiliconValleyBank::AchTransaction.new(
+        account_number: '00002323044',
+        account_type: AchClient::AccountTypes::Checking,
+        amount: BigDecimal.new('-575.45'),
+        memo: '????',
+        merchant_name: 'DOE, JOHN',
+        originator_name: 'ff',
+        routing_number: '123456780',
+        sec_code: 'CCD',
+        transaction_type: AchClient::TransactionTypes::Debit,
+        external_ach_id: '123foooo',
+        customer_id: 'foo'
+      ).to_entry_detail
+      refute(entry.debit?)
+      assert(entry.amount.positive?)
+    end
+
+    def test_swaps_negative_credit_to_positive_debit
+      entry = AchClient::SiliconValleyBank::AchTransaction.new(
+        account_number: '00002323044',
+        account_type: AchClient::AccountTypes::Checking,
+        amount: BigDecimal.new('-575.45'),
+        memo: '????',
+        merchant_name: 'DOE, JOHN',
+        originator_name: 'ff',
+        routing_number: '123456780',
+        sec_code: 'CCD',
+        transaction_type: AchClient::TransactionTypes::Credit,
+        external_ach_id: '123foooo',
+        customer_id: 'foo'
+      ).to_entry_detail
+      refute(entry.credit?)
+      assert(entry.amount.positive?)
+    end
   end
 end


### PR DESCRIPTION
Some providers (like BoA) can't handle negative values for ACH amounts.
When a negative amount is detected for a NACHA provider, we:
1) Make the amount positive by taking the absolute value
2) Switch the transaction type between debit and credit