### PR TITLE
PS-83 AchWorks modules should strip first character from external trace on both send and receive

### DIFF
--- a/lib/ach_client/providers/soap/ach_works/ach_status_checker.rb
+++ b/lib/ach_client/providers/soap/ach_works/ach_status_checker.rb
@@ -58,6 +58,7 @@ module AchClient
             record[:front_end_trace].present?
           end.map do |record|
             {
+              # Strips the first characther because it is always the added Z
               record[:front_end_trace][1..-1] =>
               AchClient::AchWorks::ResponseRecordProcessor
                 .process_response_record(record)

--- a/lib/ach_client/providers/soap/ach_works/ach_transaction.rb
+++ b/lib/ach_client/providers/soap/ach_works/ach_transaction.rb
@@ -22,7 +22,7 @@ module AchClient
             InpACHTransRecord: self.to_hash
           }),
           path: [:send_ach_trans_response, :send_ach_trans_result]
-        )[:front_end_trace]
+        )[:front_end_trace][1..-1]
       end
 
       ##

--- a/test/lib/ach_client/ach_works/ach_transaction_test.rb
+++ b/test/lib/ach_client/ach_works/ach_transaction_test.rb
@@ -137,7 +137,7 @@ class AchWorks
             external_ach_id: 'foooo',
             customer_id: 'foo'
           ).send,
-          'Zfoooo'
+          'foooo'
         )
       end
     end


### PR DESCRIPTION
We append a Z to the beginning of the external_ach_id because AchWorks demands that it not start with a W. This was being stripped by the status checker, but not by the return value for sending the ACH transaction, resulting in the string returned by the status checker not matching up with the value stored by the consumer