### PR TITLE
Add CODEOWNERS and review request github action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ForwardFinancing/funding-app-smes

--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -1,0 +1,27 @@
+name: Request PR reviewers
+
+on:
+  # To support Dependabot PRs, we need to use `pull_request_target` instead of `pull_request`.
+  #
+  # See:
+  # - https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-795140576
+  # - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  request-front-end-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          # the default GITHUB_TOKEN does not have permission to request reviews from teams.
+          # https://github.com/peter-evans/create-pull-request/issues/155#issuecomment-611904487
+          github-token: ${{ secrets.REVIEW_REQUEST_GITHUB_TOKEN }}
+          script: |
+            return github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              team_reviewers: ['ruby']
+            })


### PR DESCRIPTION
Tests are failing, but that's unrelated to this PR.

The last three commits on `main` also failed with the same error:

- 19ad367d8a30264648de3f90711944ca2d2623b4
- f02d1a85e04b01e5eb1f52bb81f6296e057d0218
- 27d6626a2025b3ec013354c7dd45dc01269c7e71

---

For more context, see https://github.com/ForwardFinancing/docs/pull/51.