### PR TITLE
using Date for icheck ach response.date

### DIFF
--- a/lib/ach_client/helpers/utils.rb
+++ b/lib/ach_client/helpers/utils.rb
@@ -12,6 +12,15 @@ module AchClient
           end
         end
       end
+
+      def self.icheck_date_format(date_string)
+        return unless date_string
+        begin
+          Date.strptime(date_string, "%m/%d/%Y")
+        rescue Date::Error
+          return date_string
+        end
+      end
     end
   end
 end

--- a/lib/ach_client/providers/soap/i_check_gateway/response_record_processor.rb
+++ b/lib/ach_client/providers/soap/i_check_gateway/response_record_processor.rb
@@ -28,13 +28,13 @@ module AchClient
           # N - no, it hasn't settled yet
           AchClient::ProcessingAchResponse.new(
             amount: record[AMOUNT_COLUMN],
-            date: record[DATE_COLUMN]
+            date: Helpers::Utils.icheck_date_format(record[DATE_COLUMN])
           )
         when 'Y'
           # Y - yes, it has settled
           AchClient::SettledAchResponse.new(
             amount: record[AMOUNT_COLUMN],
-            date: record[DATE_COLUMN]
+            date: Helpers::Utils.icheck_date_format(record[DATE_COLUMN])
           )
         else
           # If it starts with R, it is probably a return, in which case the
@@ -44,7 +44,7 @@ module AchClient
           if record[1].start_with?('R')
             AchClient::ReturnedAchResponse.new(
               amount: record[AMOUNT_COLUMN],
-              date: record[DATE_COLUMN],
+              date: Helpers::Utils.icheck_date_format(record[DATE_COLUMN]),
               return_code: AchClient::ReturnCodes.find_by(
                 code: record[STATUS_COLUMN][RETURN_CODE_INDEX]
               )

--- a/lib/ach_client/version.rb
+++ b/lib/ach_client/version.rb
@@ -1,4 +1,4 @@
 module AchClient
   # Increment this when changes are published
-  VERSION = '5.2.0'
+  VERSION = '5.3.0'
 end

--- a/test/lib/ach_client/helpers/utils_test.rb
+++ b/test/lib/ach_client/helpers/utils_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UtilsTest < MiniTest::Test
+  def test_icheck_date_format
+    assert_equal(
+      "wonky/date/format",
+      AchClient::Helpers::Utils.icheck_date_format('wonky/date/format')
+    )
+    assert_raises do
+      AchClient::Helpers::Utils.icheck_date_format(1)
+    end
+    refute(
+      AchClient::Helpers::Utils.icheck_date_format(nil)
+    )
+  end
+end

--- a/test/lib/ach_client/i_check_gateway/ach_status_checker_test.rb
+++ b/test/lib/ach_client/i_check_gateway/ach_status_checker_test.rb
@@ -14,6 +14,7 @@ class ICheckGateway
         ]
       }
     end
+
     def test_most_recent
       assert_raises(RuntimeError) do
         AchClient::ICheckGateway::AchStatusChecker.most_recent
@@ -105,49 +106,49 @@ class ICheckGateway
           'pending_and_settled' => [
             AchClient::ProcessingAchResponse.new(
               amount: '250.00',
-              date: '9/12/2016'
+              date: Date.parse('12/9/2016')
             ),
             AchClient::SettledAchResponse.new(
               amount: '250.00',
-              date: '9/12/2016'
+              date: Date.parse('12/9/2016')
             )
           ],
           'settled1' => [AchClient::SettledAchResponse.new(
             amount: '906.43',
-            date: '9/6/2016'
+            date: Date.parse('6/9/2016')
           )],
           'accountclosed' => [AchClient::ReturnedAchResponse.new(
             amount: '176.10',
-            date: '9/7/2016',
+            date: Date.parse('7/9/2016'),
             return_code: AchClient::ReturnCodes.find_by(code: 'R08')
           )],
           'nsf' => [
             AchClient::ReturnedAchResponse.new(
               amount: nil,
-              date: '2016-08-10',
+              date: Date.parse('2016-08-10'),
               return_code: AchClient::ReturnCodes.find_by(code: 'R01')
             ),
             AchClient::ReturnedAchResponse.new(
               amount: '178.75',
-              date: '9/6/2016',
+              date: Date.parse('6/9/2016'),
               return_code: AchClient::ReturnCodes.find_by(code: 'R01')
             )
           ],
           'short_late_return' => [
             AchClient::ReturnedAchResponse.new(
               amount: nil,
-              date: '2016-08-10',
+              date: Date.parse('2016-08-10'),
               return_code: AchClient::ReturnCodes.find_by(code: 'R08')
             ),
             AchClient::SettledAchResponse.new(
               amount: '123.45',
-              date: '8/10/2016'
+              date: Date.parse('10/08/2016')
             )
           ],
           'very_late_return' => [
             AchClient::ReturnedAchResponse.new(
               amount: nil,
-              date: '2016-08-11',
+              date: Date.parse('2016-08-11'),
               return_code: AchClient::ReturnCodes.find_by(code: 'R02')
             )
           ]


### PR DESCRIPTION
definitely need a sanity check here 
checking the dates from here...
https://github.com/ForwardFinancing/ach_client/blob/main/test/vcrs/icg_in_range_success.yml#L49
