### PR TITLE
ci: Start a CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: ruby:3.1.4
+    steps:
+      - checkout
+      - run:
+          name: Run the default task
+          command: |
+            gem install bundler -v 2.4.10
+            bundle install
+            bundle exec rake

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   build:
     docker:
       - image: ruby:3.1.4
+        environment:
+          TZ: America/New_York
     steps:
       - checkout
       - run:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a CircleCI build to install dependencies and run the default `rake` test task; main risk is potential CI failures due to environment/version mismatches.
> 
> **Overview**
> Adds an initial CircleCI pipeline via `.circleci/config.yml`.
> 
> The new `build` job runs on `ruby:3.1.4`, installs Bundler `2.4.10`, installs gems, and executes the default `bundle exec rake` (tests) task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6275ce04815b9d4545005baf1c467f648a6dcc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->